### PR TITLE
Modify package structure

### DIFF
--- a/src/main/java/io/github/jk6841/kakaoenterprise/ApiApplication.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/ApiApplication.java
@@ -2,8 +2,10 @@ package io.github.jk6841.kakaoenterprise;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan(basePackages = {"io.github.jk6841.kakaoenterprise.api", "io.github.jk6841.kakaoenterprise.common"})
 public class ApiApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/io/github/jk6841/kakaoenterprise/DataLoadApplication.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/DataLoadApplication.java
@@ -10,6 +10,7 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 import reactor.core.scheduler.Scheduler;
 
 import java.time.Duration;
@@ -17,6 +18,7 @@ import java.time.Instant;
 
 @Slf4j
 @SpringBootApplication
+@ComponentScan(basePackages = {"io.github.jk6841.kakaoenterprise.dataload", "io.github.jk6841.kakaoenterprise.common"})
 public class DataLoadApplication implements ApplicationRunner {
     private final FileLineReader fileLineReader;
 
@@ -45,6 +47,7 @@ public class DataLoadApplication implements ApplicationRunner {
     @Override
     public void run(ApplicationArguments args) {
         Instant start = Instant.now();
+        log.info("Starting.");
         fileLineReader.readLines()
                 .publishOn(objectScheduler)
                 .flatMap(songObjectService::convertFileLineToSong)

--- a/src/main/java/io/github/jk6841/kakaoenterprise/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/api/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package io.github.jk6841.kakaoenterprise.exception;
+package io.github.jk6841.kakaoenterprise.api.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/io/github/jk6841/kakaoenterprise/api/exception/NotFoundSongException.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/api/exception/NotFoundSongException.java
@@ -1,4 +1,4 @@
-package io.github.jk6841.kakaoenterprise.exception;
+package io.github.jk6841.kakaoenterprise.api.exception;
 
 public class NotFoundSongException extends RuntimeException {
 }

--- a/src/main/java/io/github/jk6841/kakaoenterprise/api/like/Like.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/api/like/Like.java
@@ -1,4 +1,4 @@
-package io.github.jk6841.kakaoenterprise.like;
+package io.github.jk6841.kakaoenterprise.api.like;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/io/github/jk6841/kakaoenterprise/api/like/LikeController.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/api/like/LikeController.java
@@ -1,6 +1,6 @@
-package io.github.jk6841.kakaoenterprise.like;
+package io.github.jk6841.kakaoenterprise.api.like;
 
-import io.github.jk6841.kakaoenterprise.like.api.dto.TrendingSongsResponse;
+import io.github.jk6841.kakaoenterprise.api.like.api.dto.TrendingSongsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;

--- a/src/main/java/io/github/jk6841/kakaoenterprise/api/like/LikeService.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/api/like/LikeService.java
@@ -1,9 +1,9 @@
-package io.github.jk6841.kakaoenterprise.like;
+package io.github.jk6841.kakaoenterprise.api.like;
 
-import io.github.jk6841.kakaoenterprise.exception.NotFoundSongException;
-import io.github.jk6841.kakaoenterprise.like.api.dto.TrendingSongsResponse;
-import io.github.jk6841.kakaoenterprise.like.db.LikeCustomRepository;
-import io.github.jk6841.kakaoenterprise.like.db.LikeRepository;
+import io.github.jk6841.kakaoenterprise.api.exception.NotFoundSongException;
+import io.github.jk6841.kakaoenterprise.api.like.api.dto.TrendingSongsResponse;
+import io.github.jk6841.kakaoenterprise.api.like.db.LikeCustomRepository;
+import io.github.jk6841.kakaoenterprise.api.like.db.LikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;

--- a/src/main/java/io/github/jk6841/kakaoenterprise/api/like/api/dto/TrendingSongsResponse.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/api/like/api/dto/TrendingSongsResponse.java
@@ -1,4 +1,4 @@
-package io.github.jk6841.kakaoenterprise.like.api.dto;
+package io.github.jk6841.kakaoenterprise.api.like.api.dto;
 
 import java.util.List;
 

--- a/src/main/java/io/github/jk6841/kakaoenterprise/api/like/db/LikeCustomRepository.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/api/like/db/LikeCustomRepository.java
@@ -1,6 +1,6 @@
-package io.github.jk6841.kakaoenterprise.like.db;
+package io.github.jk6841.kakaoenterprise.api.like.db;
 
-import io.github.jk6841.kakaoenterprise.like.db.dto.LikedSong;
+import io.github.jk6841.kakaoenterprise.api.like.db.dto.LikedSong;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.r2dbc.convert.MappingR2dbcConverter;
 import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;

--- a/src/main/java/io/github/jk6841/kakaoenterprise/api/like/db/LikeRepository.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/api/like/db/LikeRepository.java
@@ -1,6 +1,6 @@
-package io.github.jk6841.kakaoenterprise.like.db;
+package io.github.jk6841.kakaoenterprise.api.like.db;
 
-import io.github.jk6841.kakaoenterprise.like.Like;
+import io.github.jk6841.kakaoenterprise.api.like.Like;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 
 public interface LikeRepository extends R2dbcRepository<Like, Long> {

--- a/src/main/java/io/github/jk6841/kakaoenterprise/api/like/db/dto/LikedSong.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/api/like/db/dto/LikedSong.java
@@ -1,4 +1,4 @@
-package io.github.jk6841.kakaoenterprise.like.db.dto;
+package io.github.jk6841.kakaoenterprise.api.like.db.dto;
 
 public record LikedSong(
         Integer likes,

--- a/src/main/java/io/github/jk6841/kakaoenterprise/common/config/ObjectMapperConfig.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/common/config/ObjectMapperConfig.java
@@ -1,4 +1,4 @@
-package io.github.jk6841.kakaoenterprise.config;
+package io.github.jk6841.kakaoenterprise.common.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/io/github/jk6841/kakaoenterprise/common/config/r2dbc/R2dbcConfig.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/common/config/r2dbc/R2dbcConfig.java
@@ -1,4 +1,4 @@
-package io.github.jk6841.kakaoenterprise.config.r2dbc;
+package io.github.jk6841.kakaoenterprise.common.config.r2dbc;
 
 import io.r2dbc.spi.ConnectionFactory;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/io/github/jk6841/kakaoenterprise/common/song/SimilarSong.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/common/song/SimilarSong.java
@@ -1,4 +1,4 @@
-package io.github.jk6841.kakaoenterprise.song;
+package io.github.jk6841.kakaoenterprise.common.song;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/io/github/jk6841/kakaoenterprise/common/song/Song.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/common/song/Song.java
@@ -1,4 +1,4 @@
-package io.github.jk6841.kakaoenterprise.song;
+package io.github.jk6841.kakaoenterprise.common.song;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/io/github/jk6841/kakaoenterprise/dataload/SongFactory.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/dataload/SongFactory.java
@@ -1,8 +1,8 @@
 package io.github.jk6841.kakaoenterprise.dataload;
 
 import io.github.jk6841.kakaoenterprise.dataload.file.FileLine;
-import io.github.jk6841.kakaoenterprise.song.SimilarSong;
-import io.github.jk6841.kakaoenterprise.song.Song;
+import io.github.jk6841.kakaoenterprise.common.song.SimilarSong;
+import io.github.jk6841.kakaoenterprise.common.song.Song;
 import org.springframework.stereotype.Component;
 
 import java.util.List;

--- a/src/main/java/io/github/jk6841/kakaoenterprise/dataload/SongObjectService.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/dataload/SongObjectService.java
@@ -1,7 +1,7 @@
 package io.github.jk6841.kakaoenterprise.dataload;
 
 import io.github.jk6841.kakaoenterprise.dataload.file.FileLineDeserializer;
-import io.github.jk6841.kakaoenterprise.song.Song;
+import io.github.jk6841.kakaoenterprise.common.song.Song;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;

--- a/src/main/java/io/github/jk6841/kakaoenterprise/dataload/db/DbSaveService.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/dataload/db/DbSaveService.java
@@ -1,6 +1,6 @@
 package io.github.jk6841.kakaoenterprise.dataload.db;
 
-import io.github.jk6841.kakaoenterprise.song.Song;
+import io.github.jk6841.kakaoenterprise.common.song.Song;
 import io.r2dbc.spi.Statement;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/io/github/jk6841/kakaoenterprise/dataload/db/QueryGenerator.java
+++ b/src/main/java/io/github/jk6841/kakaoenterprise/dataload/db/QueryGenerator.java
@@ -2,7 +2,7 @@ package io.github.jk6841.kakaoenterprise.dataload.db;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.jk6841.kakaoenterprise.song.Song;
+import io.github.jk6841.kakaoenterprise.common.song.Song;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.Statement;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/io/github/jk6841/kakaoenterprise/dataload/SongFactoryTest.java
+++ b/src/test/java/io/github/jk6841/kakaoenterprise/dataload/SongFactoryTest.java
@@ -1,14 +1,13 @@
 package io.github.jk6841.kakaoenterprise.dataload;
 
 import io.github.jk6841.kakaoenterprise.dataload.file.FileLine;
-import io.github.jk6841.kakaoenterprise.song.SimilarSong;
-import io.github.jk6841.kakaoenterprise.song.Song;
+import io.github.jk6841.kakaoenterprise.common.song.SimilarSong;
+import io.github.jk6841.kakaoenterprise.common.song.Song;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 class SongFactoryTest {
     private final SongFactory songFactory = new SongFactory();


### PR DESCRIPTION
### 변경 이유
- `ApiApplication`이 기동될 때 `DataLoadApplication`도 스캔 되어 data loading이 실행됨

### 변경 내용
- 패키지 구조를 아래와 같이 변경함
  - `io.github.jk6841.kakaoenterprise`
    - `api` -> `ApiApplication` 전용 패키지
    - `dataload` -> `DataLoadApplication` 전용 패키지
    - `common` -> 공통 패키지
- 각 SpringBootApplication 클래스에는 `@ComponentScan` 설정 추가